### PR TITLE
Fix goTo offset calculation

### DIFF
--- a/src/components/GridPainter.vue
+++ b/src/components/GridPainter.vue
@@ -470,8 +470,9 @@ function zoomOut() {
 }
 
 function goTo(x:number, y:number) {
-  offset.value.x = x * TILE - (x * TILE + TILE / 2)
-  offset.value.y = y * TILE - (y * TILE + TILE / 2)
+  const c = canvas.value!
+  offset.value.x = c.clientWidth / 2 - (x + 0.5) * TILE * scale.value
+  offset.value.y = c.clientHeight / 2 - (y + 0.5) * TILE * scale.value
   draw()
 }
 


### PR DESCRIPTION
## Summary
- correctly center view on provided coordinates in `goTo`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8eb98f1848323b85bd56bd1324222